### PR TITLE
Pecl geoip extension is now optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.1,<2.4-dev",
         "symfony/yaml": ">=2.1,<2.4-dev",
-        "symfony/validator": ">=2.1,<2.4-dev",
-        "ext-geoip": "*"
+        "symfony/validator": ">=2.1,<2.4-dev"
     },
     "require-dev": {
         "ext-intl": "*"
     },
     "suggest": {
-          "ext-intl": "Always a good idea :)"
+          "ext-intl": "Always a good idea :)",
+          "ext-geoip": "*"
     },
     "autoload": {
         "psr-0": { "Lunetics\\TimezoneBundle": "" }


### PR DESCRIPTION
I've noticed that after 28f9f597c403a3f71c21459bef8be29ddd29b431 geoip extension became required. As its relative guesser is optional I thought moving it under suggestions packages would be more appropriate.
